### PR TITLE
Fix product data caching

### DIFF
--- a/src/API/PdfGeneratorApiResponse.php
+++ b/src/API/PdfGeneratorApiResponse.php
@@ -480,6 +480,8 @@ class PdfGeneratorApiResponse implements CallableApiResponse {
 		$entry['date_created'] = current_time( 'mysql', true );
 		$entry['id']           = $this->get_unique_id();
 
+		gform_delete_meta( $entry['id'] );
+
 		return $entry;
 	}
 


### PR DESCRIPTION
Gravity Forms was caching the product data over multiple refreshes (uniqid() can create non-unique numbers).

Temporarily fix is to delete the cache.

May want to replace uniqid() with a function that is actually unique. 