### PR TITLE
Allow PDF Preview to be downloaded using a toggle option in the UI

### DIFF
--- a/assets/js/Previewer/Viewer.js
+++ b/assets/js/Previewer/Viewer.js
@@ -45,6 +45,7 @@ export default class {
 
     this.viewerUrl = args.viewer
     this.documentUrl = args.documentUrl
+    this.download = args.download
   }
 
   /**
@@ -57,9 +58,15 @@ export default class {
    * @since 0.1
    */
   create (id) {
+    let pdfUrl = this.viewerUrl + this.documentUrl + id;
+
+    if(this.download === 1) {
+      pdfUrl = pdfUrl + '&download=1';
+    }
+
     this.remove()
     this.$iframe = $('<iframe>')
-      .attr('src', this.viewerUrl + this.documentUrl + id)
+      .attr('src', pdfUrl)
       .attr('frameborder', 0)
       .width('100%')
       .height(this.viewerHeight)

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -43,6 +43,8 @@ $(document).bind('gform_post_render', function (e, formId) {
     let fieldId = parseInt($(this).data('field-id'))
     let pdfId = $(this).data('pdf-id')
     let previewerHeight = parseInt($(this).data('previewer-height'))
+    let download = (typeof $(this).data('download') !== 'undefined') ? parseInt($(this).data('download')) : 0;
+    console.log(download)
 
     /* Continue to next matched element if no PDF ID exists */
     if (pdfId == 0) {
@@ -56,7 +58,8 @@ $(document).bind('gform_post_render', function (e, formId) {
     let viewer = new Viewer({
       viewerHeight: previewerHeight + 'px',
       viewer: PdfPreviewerConstants.viewerUrl,
-      documentUrl: PdfPreviewerConstants.documentUrl
+      documentUrl: PdfPreviewerConstants.documentUrl,
+      download
     })
 
     let previewer = new Generator({

--- a/assets/viewer.php
+++ b/assets/viewer.php
@@ -50,10 +50,16 @@ See https://github.com/adobe-type-tools/cmap-resources
         #findbar,
         #secondaryToolbar,
         #sidebarToggle,
-        #toolbarViewerRight,
-        #viewFind {
+        #viewFind,
+        #toolbarViewerRight > *{
             display: none !important;
         }
+
+        <?php if ( isset( $_GET['download'] ) && (int) $_GET['download'] === 1 ): ?>
+            #toolbarViewerRight > #download {
+                display: block !important;
+            }
+        <?php endif; ?>
 
         #toolbarViewerMiddle {
             float: right;

--- a/src/Field/GFormFieldPreviewer.php
+++ b/src/Field/GFormFieldPreviewer.php
@@ -99,6 +99,7 @@ class GFormFieldPreviewer extends GF_Field {
 			$field_id       = $this->id;
 			$pdf_id         = ( isset( $this->pdfpreview ) ) ? $this->pdfpreview : $this->get_pdf_id_if_any( $form );
 			$preview_height = ( isset( $this->pdfpreviewheight ) && (int) $this->pdfpreviewheight > 0 ) ? (int) $this->pdfpreviewheight : 600;
+			$download       = ( isset( $this->pdfdownload ) ) ? (int) $this->pdfdownload : 0;
 
 			include __DIR__ . '/markup/previewer-wrapper.php';
 		}
@@ -141,6 +142,7 @@ class GFormFieldPreviewer extends GF_Field {
 			'pdf_selector_setting',
 			'pdf_preview_height_setting',
 			'pdf_watermark_setting',
+			'pdf_download_setting'
 		];
 	}
 

--- a/src/Field/RegisterPreviewerCustomFields.php
+++ b/src/Field/RegisterPreviewerCustomFields.php
@@ -67,6 +67,7 @@ class RegisterPreviewerCustomFields implements Helper_Interface_Actions, Helper_
 	public function add_actions() {
 		add_action( 'gform_field_standard_settings', [ $this, 'add_pdf_selector' ], 10, 2 );
 		add_action( 'gform_field_standard_settings', [ $this, 'add_pdf_preview_height' ] );
+		add_action( 'gform_field_standard_settings', [ $this, 'add_pdf_download_support' ] );
 		add_action( 'gform_field_standard_settings', [ $this, 'add_pdf_watermark_support' ] );
 		add_action( 'gform_editor_js', [ $this, 'editor_js' ] );
 	}
@@ -169,6 +170,20 @@ class RegisterPreviewerCustomFields implements Helper_Interface_Actions, Helper_
 
 			$font_stack = GPDFAPI::get_pdf_fonts();
 			include __DIR__ . '/markup/pdf-watermark-setting.php';
+		}
+	}
+
+	/**
+	 * Add support for PDF Download Toggle in the Form Editor
+	 *
+	 * @param init $position
+	 *
+	 * @since 0.1
+	 */
+	public function add_pdf_download_support( $position ) {
+		if ( $position === 25 ) {
+			$this->get_logger()->addNotice( 'Add PDF Download toggle to form editor' );
+			include __DIR__ . '/markup/pdf-download-setting.php';
 		}
 	}
 

--- a/src/Field/RegisterPreviewerField.php
+++ b/src/Field/RegisterPreviewerField.php
@@ -104,7 +104,7 @@ class RegisterPreviewerField implements Helper_Interface_Actions {
 				'gfpdf_previewer',
 				'PdfPreviewerConstants',
 				[
-					'viewerUrl'            => plugin_dir_url( GFPDF_PDF_PREVIEWER_FILE ) . 'dist/viewer/web/viewer.html?file=',
+					'viewerUrl'            => plugin_dir_url( GFPDF_PDF_PREVIEWER_FILE ) . 'dist/viewer/web/viewer.php?file=',
 					'documentUrl'          => rest_url( 'gravity-pdf-previewer/v1/pdf/' ),
 					'pdfGeneratorEndpoint' => rest_url( 'gravity-pdf-previewer/v1/generator/' ),
 

--- a/src/Field/markup/editor.js
+++ b/src/Field/markup/editor.js
@@ -38,6 +38,10 @@
     $("#pdf_watermark_font").trigger('change')
   }
 
+  function setupDownload (field) {
+    $('#pdf-download-setting').prop('checked', field['pdfdownload'] == true)
+  }
+
   $(document).bind("gform_load_field_settings", function (event, field) {
     if (field.type === 'pdfpreview') {
       setupPdfSelector(field)
@@ -45,6 +49,7 @@
       setupWatermarkToggle(field)
       setupWatermarkText(field)
       setupWatermarkFont(field)
+      setupDownload(field)
     }
   })
 })(jQuery)

--- a/src/Field/markup/pdf-download-setting.php
+++ b/src/Field/markup/pdf-download-setting.php
@@ -1,0 +1,10 @@
+<li class="pdf_download_setting field_setting">
+    <label class="section_label"><?php esc_html_e( 'Download Preview', 'gravity-pdf-previewer' ) ?></label>
+    <input type="checkbox"
+           id="pdf-download-setting"
+           onclick="SetFieldProperty('pdfdownload', this.checked)"/>
+
+    <label for="pdf-download-setting" class="inline">
+		<?php esc_html_e( 'Allow user to download the PDF Preview?', 'gravity-pdf-previewer' ); ?>
+    </label>
+</li>

--- a/src/Field/markup/previewer-wrapper.php
+++ b/src/Field/markup/previewer-wrapper.php
@@ -1,6 +1,7 @@
 <div class="gpdf-previewer-wrapper"
      data-field-id="<?php echo esc_attr( $field_id ); ?>"
      data-pdf-id="<?php echo esc_attr( $pdf_id ); ?>"
-     data-previewer-height="<?php echo esc_attr( $preview_height ); ?>">
+     data-previewer-height="<?php echo esc_attr( $preview_height ); ?>"
+     <?php if ( (int) $download === 1 ): ?>data-download="<?php echo esc_attr( $download ); ?>"<?php endif; ?>>
     <!-- Placeholder -->
 </div>

--- a/tests/phpunit/unit-tests/Field/RegisterPreviewerCustomFields.php
+++ b/tests/phpunit/unit-tests/Field/RegisterPreviewerCustomFields.php
@@ -106,10 +106,6 @@ class TestRegisterPreviewerCustomFields extends WP_UnitTestCase {
 	 * @since 0.1
 	 */
 	public function test_add_pdf_preview_height() {
-		$_SERVER['HTTP_USER_AGENT'] = 'cli';
-		$form                       = json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/../../json/all-form-fields.json' ) ), true );
-		$form_id                    = GFAPI::add_form( $form );
-
 		ob_start();
 		$this->class->add_pdf_preview_height( 25 );
 		$html = ob_get_clean();
@@ -118,19 +114,12 @@ class TestRegisterPreviewerCustomFields extends WP_UnitTestCase {
 		$markup = $qp->html5( $html );
 
 		$this->assertEquals( 'input', $markup->find( '#pdf_preview_height' )->tag() );
-
-		/* Cleanup */
-		GFAPI::delete_form( $form_id );
 	}
 
 	/**
 	 * @since 0.1
 	 */
 	public function test_pdf_watermark_support() {
-		$_SERVER['HTTP_USER_AGENT'] = 'cli';
-		$form                       = json_decode( trim( file_get_contents( dirname( __FILE__ ) . '/../../json/all-form-fields.json' ) ), true );
-		$form_id                    = GFAPI::add_form( $form );
-
 		ob_start();
 		$this->class->add_pdf_watermark_support( 25 );
 		$html = ob_get_clean();
@@ -141,8 +130,19 @@ class TestRegisterPreviewerCustomFields extends WP_UnitTestCase {
 		$this->assertEquals( 'checkbox', $markup->find( '#pdf-watermark-setting' )->attr( 'type' ) );
 		$this->assertEquals( 'input', $markup->find( '#pdf_watermark_text' )->tag() );
 		$this->assertEquals( 'select', $markup->find( '#pdf_watermark_font' )->tag() );
+	}
 
-		/* Cleanup */
-		GFAPI::delete_form( $form_id );
+	/**
+	 * @since 1.1
+	 */
+	public function test_download_support() {
+		ob_start();
+		$this->class->add_pdf_download_support( 25 );
+		$html = ob_get_clean();
+
+		$qp     = new Helper_QueryPath();
+		$markup = $qp->html5( $html );
+
+		$this->assertEquals( 'checkbox', $markup->find( '#pdf-download-setting' )->attr( 'type' ) );
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,8 +84,8 @@ module.exports = {
       ignore: [ '*.pdf' ]
     },
       {
-        from: 'assets/viewer.html',
-        to: __dirname + '/dist/viewer/web/viewer.html',
+        from: 'assets/viewer.php',
+        to: __dirname + '/dist/viewer/web/viewer.php',
         force: true
       }])
   ]


### PR DESCRIPTION
The Form Editor Preview field now includes a setting to show the PDF Download button in the Previewer. By default this is disabled but admins can enable it when needed.

Add unit test support for new field type

Resolves #10