### PR TITLE
When the PDF download option is enabled, delete the PDF after the 2nd time loading

### DIFF
--- a/assets/js/Previewer/Viewer.js
+++ b/assets/js/Previewer/Viewer.js
@@ -58,10 +58,10 @@ export default class {
    * @since 0.1
    */
   create (id) {
-    let pdfUrl = this.viewerUrl + this.documentUrl + id;
+    let pdfUrl = this.viewerUrl + '?file=' + encodeURIComponent(this.documentUrl + id)
 
-    if(this.download === 1) {
-      pdfUrl = pdfUrl + '&download=1';
+    if (this.download === 1) {
+      pdfUrl = this.viewerUrl + '?download=1&file=' + encodeURIComponent(this.documentUrl + id + '?download=1')
     }
 
     this.remove()

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,7 +44,6 @@ $(document).bind('gform_post_render', function (e, formId) {
     let pdfId = $(this).data('pdf-id')
     let previewerHeight = parseInt($(this).data('previewer-height'))
     let download = (typeof $(this).data('download') !== 'undefined') ? parseInt($(this).data('download')) : 0;
-    console.log(download)
 
     /* Continue to next matched element if no PDF ID exists */
     if (pdfId == 0) {

--- a/src/API/PdfGeneratorApiResponse.php
+++ b/src/API/PdfGeneratorApiResponse.php
@@ -158,7 +158,10 @@ class PdfGeneratorApiResponse implements CallableApiResponse {
 			$this->entry    = apply_filters( 'gfpdf_previewer_created_entry', $this->create_entry( $this->form ), $this->form, $this->settings, $input, $request );
 
 			/* Try create our PDF and return the Unique ID we assigned to the preview if successful */
-			$this->generate_pdf( $this->entry, $this->settings );
+			$pdf_path = $this->generate_pdf( $this->entry, $this->settings );
+
+			/* Set the last access time to the current hour for ad-hoc security in PdfViewerApiResponse */
+			touch( $pdf_path, time(), mktime( null, 0, 0 ) );
 
 			do_action( 'gfpdf_previewer_end_pdf_generation', $request, $this->form, $this->entry, $this->settings, $input );
 

--- a/src/Field/RegisterPreviewerField.php
+++ b/src/Field/RegisterPreviewerField.php
@@ -106,7 +106,7 @@ class RegisterPreviewerField implements Helper_Interface_Actions {
 				'gfpdf_previewer',
 				'PdfPreviewerConstants',
 				[
-					'viewerUrl'            => plugin_dir_url( GFPDF_PDF_PREVIEWER_FILE ) . 'dist/viewer/web/viewer.php?file=',
+					'viewerUrl'            => plugin_dir_url( GFPDF_PDF_PREVIEWER_FILE ) . 'dist/viewer/web/viewer.php',
 					'documentUrl'          => rest_url( 'gravity-pdf-previewer/v1/pdf/' ),
 					'pdfGeneratorEndpoint' => rest_url( 'gravity-pdf-previewer/v1/generator/' ),
 

--- a/tests/mocha/unit-tests/Previewer/Viewer.test.js
+++ b/tests/mocha/unit-tests/Previewer/Viewer.test.js
@@ -22,7 +22,7 @@ describe('Viewer Class', () => {
 
     let $iframe = viewer.create('testID')
 
-    expect($iframe.attr('src')).to.equal('viewerUrldocumentUrltestID')
+    expect($iframe.attr('src')).to.equal('viewerUrl?file=documentUrltestID')
     expect($iframe.height()).to.equal(500)
   })
 


### PR DESCRIPTION
Some browsers will give users the cached copy of the PDF when using the download feature. Others will try download it from the source instead (including Chrome on iPhone and Windows Safari). This PR allows users who have the PDF configured for download to access the document from the source one time. It'll be deleted the 2nd time it's accessed.