### PR TITLE
Prevent the auto-PDF refresher from triggering after submission

### DIFF
--- a/assets/js/Previewer/Generator.js
+++ b/assets/js/Previewer/Generator.js
@@ -106,7 +106,7 @@ export default class {
      * the form has been updated AND the previewer container is in the browser viewpoint
      * then we'll generate a new preview
      */
-    if (!this.viewer.doesViewerExist() || ( this.formUpdated && this.isContainerInViewpoint() )) {
+    if (!this.viewer.doesViewerExist() || (window['gf_submitting_' + this.$form.data('fid')] == null && this.formUpdated && this.isContainerInViewpoint())) {
       this.generatePreview()
     }
   }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -35,12 +35,19 @@ require('../scss/previewer.scss')
  * @since 0.1
  */
 $(document).bind('gform_post_render', function (e, formId) {
+  /* Don't run if currently submitting the form */
+  if (window['gf_submitting_' + formId]) {
+    return
+  }
+
   let $form = $('#gform_' + formId)
 
   /* Try match a slightly different mark-up */
   if ($form.length == 0) {
     $form = $('#gform_wrapper_' + formId).closest('form')
   }
+
+  $form.data('fid', formId)
 
   /* Find each PDF Preview container in the form and initialise */
   $form.find('.gpdf-previewer-wrapper').each(function () {


### PR DESCRIPTION
This resolves a bug on Mac with AJAX forms which are doing an extra paint on submit.