### PR TITLE
Only override the entry object initially

### DIFF
--- a/src/API/PdfGeneratorApiResponse.php
+++ b/src/API/PdfGeneratorApiResponse.php
@@ -688,6 +688,8 @@ class PdfGeneratorApiResponse implements CallableApiResponse {
 	 * @since 0.1
 	 */
 	public function override_entry( $entry ) {
+		remove_filter( 'gfpdf_entry_pre_form_data', [ $this, 'override_entry'] );
+
 		return $this->entry;
 	}
 }


### PR DESCRIPTION
This prevents a conflict with calling `GPDFAPI::get_form_data()` from within the template.

Resolves #51