### PR TITLE
Make REST endpoint explicitly public

### DIFF
--- a/src/API/RegisterPdfGeneratorAPIEndpoint.php
+++ b/src/API/RegisterPdfGeneratorAPIEndpoint.php
@@ -3,7 +3,6 @@
 namespace GFPDF\Plugins\Previewer\API;
 
 use GFPDF\Helper\Helper_Interface_Actions;
-
 use WP_REST_Server;
 
 /**
@@ -86,13 +85,15 @@ class RegisterPdfGeneratorAPIEndpoint implements Helper_Interface_Actions {
 	 */
 	public function register_endpoint() {
 		register_rest_route( 'gravity-pdf-previewer/v1', '/generator/(?P<pid>[a-zA-Z0-9]+)', [
-			'methods'  => WP_REST_Server::EDITABLE,
-			'callback' => [ $this->response, 'response' ],
+			'methods'             => WP_REST_Server::EDITABLE,
+			'callback'            => [ $this->response, 'response' ],
+			'permission_callback' => '__return_true',
 		] );
 
 		register_rest_route( 'gravity-pdf-previewer/v1', '/generator/(?P<pid>[a-zA-Z0-9]+)/(?P<fid>\d+)', [
-			'methods'  => WP_REST_Server::EDITABLE,
-			'callback' => [ $this->response, 'response' ],
+			'methods'             => WP_REST_Server::EDITABLE,
+			'callback'            => [ $this->response, 'response' ],
+			'permission_callback' => '__return_true',
 		] );
 	}
 }

--- a/src/API/RegisterPdfViewerAPIEndpoint.php
+++ b/src/API/RegisterPdfViewerAPIEndpoint.php
@@ -3,7 +3,6 @@
 namespace GFPDF\Plugins\Previewer\API;
 
 use GFPDF\Helper\Helper_Interface_Actions;
-
 use WP_REST_Server;
 
 /**
@@ -86,8 +85,9 @@ class RegisterPdfViewerAPIEndpoint implements Helper_Interface_Actions {
 	 */
 	public function register_endpoint() {
 		register_rest_route( 'gravity-pdf-previewer/v1', '/pdf/(?P<temp_id>[a-zA-Z0-9]+)', [
-			'methods'  => WP_REST_Server::READABLE,
-			'callback' => [ $this->response, 'response' ],
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => [ $this->response, 'response' ],
+			'permission_callback' => '__return_true',
 		] );
 	}
 }


### PR DESCRIPTION
This fixes the WordPress `_doing_it_wrong` notice that would be displayed in WordPress 5.5.