### PR TITLE
Previewer show at correct time on User Input step

### DIFF
--- a/tests/phpunit/unit-tests/ThirdParty/GravityFlow.php
+++ b/tests/phpunit/unit-tests/ThirdParty/GravityFlow.php
@@ -202,10 +202,10 @@ class TestGravityFlow extends WP_UnitTestCase {
 	 */
 	public function test_override_previewer_field_display() {
 		$field = new Field();
-		$this->assertFalse( $this->class->override_previewer_field_display( false, $field ) );
+		$this->assertFalse( $this->class->override_previewer_field_display( false, $field, [], [], null ) );
 
 		$field->type = 'pdfpreview';
-		$this->assertTrue( $this->class->override_previewer_field_display( false, $field ) );
+		$this->assertTrue( $this->class->override_previewer_field_display( false, $field, [], [], null ) );
 	}
 
 	/**


### PR DESCRIPTION
A recent change https://github.com/gravityflow/gravityflow/commit/00c097dbc165b0cb183d2cd3157e2cfc4637ccc7 to how GravityFlow handles the display / hidden checks caused a regression in our Previewer display logic. This PR resolves this issue so that it'll be correctly shown under all circumstances:

1. Show all fields
2. Hide all fields except
3. Show all fields except
4. Conditional Logic on the Previewer field in conjunction with any of the above
5. Conditional Logic disabled on the fields plus 1/2/3 above.